### PR TITLE
Culler service the 'manual' way

### DIFF
--- a/setup_cull/cull/Dockerfile
+++ b/setup_cull/cull/Dockerfile
@@ -7,5 +7,3 @@ WORKDIR /srv/cull
 #ADD https://raw.githubusercontent.com/jupyter/jupyterhub/master/examples/cull-idle/cull_idle_servers.py /srv/cull/cull_idle_servers.py
 ADD cull_idle_servers.py /srv/cull/cull_idle_servers.py
 
-ENTRYPOINT ["python", "cull_idle_servers.py"]
-CMD ["--timeout=3600", "--cull_every=600", "--url=http://10.7.252.46:80/hub"]

--- a/setup_cull/hub/jupyterhub_config.py
+++ b/setup_cull/hub/jupyterhub_config.py
@@ -29,3 +29,8 @@ c.KubeSpawner.hub_ip_connect = '{host}:{port}'.format(
 
 # Do not use any authentication at all
 c.JupyterHub.authenticator_class = 'dummyauthenticator.DummyAuthenticator'
+
+# API tokens for cull service
+c.JupyterHub.api_tokens = {
+    os.environ['CULL_JHUB_TOKEN']: 'cull',
+}

--- a/setup_cull/manifest.yaml
+++ b/setup_cull/manifest.yaml
@@ -20,18 +20,6 @@ spec:
       port: 80
       targetPort: 8000
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  name: cull
-spec:
-  selector:
-    name: cull-pod
-  ports:
-    - protocol: TCP
-      port: 8081
-      targetPort: 8081
----
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -75,6 +63,3 @@ spec:
               configMapKeyRef:
                 name: hub-config
                 key: auth.configproxy-token
-          ports:
-            - containerPort: 8081
-              name: cull

--- a/setup_cull/manifest.yaml
+++ b/setup_cull/manifest.yaml
@@ -57,6 +57,15 @@ spec:
       containers:
         - name: cull-container
           image: allanlwu/jhub-cull
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - python
+            - /srv/cull/cull_idle_servers.py
+            - --timeout=3600
+            - --cull_every=600
+            - --url=http://${HUB_PROXY_SERVICE_HOST}:${HUB_PROXY_SERVICE_PORT}/hub
           env:
           - name: JPY_API_TOKEN
             valueFrom:

--- a/setup_cull/manifest.yaml
+++ b/setup_cull/manifest.yaml
@@ -7,6 +7,16 @@ data:
   # Please generate a new one for your own deployment!
   auth.configproxy-token: 5166c5fe58744ffd9ab4ec3f37c2c7b5b05b3c14d7dd7da58ae406ab7e61d349
 ---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: cull-config
+data:
+  # Used to authenticate the culler to the hub. This string was generated with `pwgen 64`.
+  # Please generate a new one for your own deployment!
+  # Note: This is a jupyterhub token, totally different from proxy auth token!
+  auth.jhub-token.cull: aiph8Dei8LotheV2coh5Aifeagha7idaeh6oogoh3ooGabi2ahng1eejahnieKah
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -39,6 +49,12 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: CULL_JHUB_TOKEN
+            valueFrom:
+              configMapKeyRef:
+                name: cull-config
+                value: auth.jhub-token.cull
+
           ports:
             - containerPort: 8000
               name: hub-proxy-port
@@ -70,5 +86,5 @@ spec:
           - name: JPY_API_TOKEN
             valueFrom:
               configMapKeyRef:
-                name: hub-config
-                key: auth.configproxy-token
+                name: cull-config
+                value: auth.jhub-token.cull


### PR DESCRIPTION
We create a secret JupyterHub API token, then we tell JupyterHub to accept API requests from clients bearing that token. We also then give the same token to culler, and point it at the hub.