### PR TITLE
Push and use Docker images from data8 Dockerhub

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,13 +30,13 @@ help:
 # This is a simple check that is used to prevent accidental pushes since
 # Travis should be building our images.
 environment-check:
-	test -e ~/.docker-stacks-builder
+	test -e ~/.jhub-k8s-images-builder
 
 refresh/%: ## pull the latest image from Docker Hub for a stack
 # skip if error: a stack might not be on dockerhub yet
 	-docker pull $(DHUB_ORG)/$(IMAGE_PREFIX)$(notdir $@):latest
 
-refresh-all: $(ALL_IMAGES:%=refresh/%) ## refresh all stacks
+refresh-all: $(ALL_IMAGES:%=refresh/%) ## refresh all images
 
 build/%: DARGS?=
 build/%: ## build the latest image for a component
@@ -50,7 +50,7 @@ tag/%: ## tag the latest component image with the HEAD git SHA
 	docker tag $(DHUB_ORG)/$(IMAGE_PREFIX)$(notdir $@):latest \
 		$(DHUB_ORG)/$(IMAGE_PREFIX)$(notdir $@):$(GIT_MASTER_HEAD_SHA)
 
-tag-all: $(ALL_IMAGES:%=tag/%) ## tag all stacks
+tag-all: $(ALL_IMAGES:%=tag/%) ## tag all images
 
 push/%: ## push the latest and HEAD git SHA tags for a component to Docker Hub
 	docker push $(DHUB_ORG)/$(IMAGE_PREFIX)$(notdir $@):latest
@@ -63,4 +63,4 @@ release-all: environment-check \
 	build-all \
 	tag-all \
 	push-all
-release-all: ## build, tag, and push all stacks
+release-all: ## build, tag, and push all images

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,66 @@
+# Based off the jupyter/docker-stacks repo. For reference:
+# https://github.com/jupyter/docker-stacks/blob/master/Makefile
+#
+# This Makefile builds the individual component images for our deployment. Each
+# image is named data8/jupyterhub-k8s-<name> where <name> is the name of the
+# component (eg. cull).
+#
+# When creating a new image, first create the repo on Docker Hub under the
+# data8 org. Then, add it to the ALL_IMAGES variable below.
+
+.PHONY: help environment-check
+
+ALL_IMAGES:=cull \
+	hub
+
+# This prefixes all our image names
+IMAGE_PREFIX:=jupyterhub-k8s-
+
+DHUB_ORG:=data8
+
+# Grabs the SHA of the latest commit for tagging purposes
+GIT_MASTER_HEAD_SHA:=$(shell git rev-parse --short=12 --verify HEAD)
+
+help:
+# http://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
+	@echo "data-8/jupyterhub-k8s"
+	@echo "====================="
+	@grep -E '^[a-zA-Z0-9_%/-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
+
+# This is a simple check that is used to prevent accidental pushes since
+# Travis should be building our images.
+environment-check:
+	test -e ~/.docker-stacks-builder
+
+refresh/%: ## pull the latest image from Docker Hub for a stack
+# skip if error: a stack might not be on dockerhub yet
+	-docker pull $(DHUB_ORG)/$(IMAGE_PREFIX)$(notdir $@):latest
+
+refresh-all: $(ALL_IMAGES:%=refresh/%) ## refresh all stacks
+
+build/%: DARGS?=
+build/%: ## build the latest image for a component
+	docker build $(DARGS) --rm --force-rm \
+		-t $(DHUB_ORG)/$(IMAGE_PREFIX)$(notdir $@):latest \
+		./$(notdir $@)
+
+build-all: $(ALL_IMAGES:%=build/%) ## build all images
+
+tag/%: ## tag the latest component image with the HEAD git SHA
+	docker tag $(DHUB_ORG)/$(IMAGE_PREFIX)$(notdir $@):latest \
+		$(DHUB_ORG)/$(IMAGE_PREFIX)$(notdir $@):$(GIT_MASTER_HEAD_SHA)
+
+tag-all: $(ALL_IMAGES:%=tag/%) ## tag all stacks
+
+push/%: ## push the latest and HEAD git SHA tags for a component to Docker Hub
+	docker push $(DHUB_ORG)/$(IMAGE_PREFIX)$(notdir $@):latest
+	docker push $(DHUB_ORG)/$(IMAGE_PREFIX)$(notdir $@):$(GIT_MASTER_HEAD_SHA)
+
+push-all: $(ALL_IMAGES:%=push/%) ## push all images
+
+release-all: environment-check \
+	refresh-all \
+	build-all \
+	tag-all \
+	push-all
+release-all: ## build, tag, and push all stacks

--- a/README.md
+++ b/README.md
@@ -33,6 +33,21 @@ That deploys JupyterHub!
 [minikube]: https://github.com/kubernetes/minikube#minikube
 [kubectl]: http://kubernetes.io/docs/user-guide/prereqs/
 
+File / Folder structure
+-------
+
+The `manifest.yaml` file in the project root directory contains the entirety of
+the Kubenetes configuration for this deployment.
+
+The subdirectories contain the Dockerfiles and scripts for the images used for
+this deployment.
+
+All the images for this deployment are pushed to the [data8 Docker Hub][]
+organization and are named `data8/jupyterhub-k8s-<name>` where `<name>` is the
+name of the containing folder for that image.
+
+[data8 Docker Hub]: http://hub.docker.com/r/data8/
+
 Development
 -------
 

--- a/cull/Dockerfile
+++ b/cull/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.6-slim
 
 RUN pip install tornado python-dateutil
 

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -32,7 +32,7 @@ spec:
       spec:
         containers:
         - name: hub-proxy-container
-          image: derrickmar24/jhub
+          image: data8/jupyterhub-k8s-hub:latest
           env:
           - name: POD_NAMESPACE
             valueFrom:
@@ -60,7 +60,7 @@ spec:
     spec:
       containers:
         - name: cull-container
-          image: derrickmar24/jhub-cull
+          image: data8/jupyterhub-k8s-cull:latest
           command:
             - /bin/sh
             - -c


### PR DESCRIPTION
Closes #21.

Before, we pushed our images to @derrickmar 's Docker Hub account. We want to use the data8 org instead, so this PR does that.

This PR also adds a Makefile that is used to automatically build and push Docker images to Docker Hub. It'll soon be used by Travis CI to automatically push images when master is pushed which means we probably won't have to use it ourselves.