### PR TITLE
Allow building and pushing images on another branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,15 +49,13 @@ before_install:
   - kubectl cluster-info
 
 script:
-- make build-all
+- make build-all BRANCH=$TRAVIS_BRANCH
 
-# Release the images when the master branch is merged, then deploy config to
-# staging cluster.
+# Release the images and deploy config to staging cluster if on master
 after_success:
-- if [ "$TRAVIS_BRANCH" == "master" ]; then
-    touch ~/.jhub-k8s-images-builder ;
-    docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD" ;
-    make release-all ;
+- docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
+- make release-all BRANCH=$TRAVIS_BRANCH
 
+- if [ "$TRAVIS_BRANCH" == "master" ]; then
     kubectl apply -f manifest.yaml ;
   fi

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ tag/%: ## tag the latest component image with the HEAD git SHA
 
 tag-all: $(ALL_IMAGES:%=tag/%) ## tag all images
 
-push/%: ## push the latest and HEAD git SHA tags for a component to Docker Hub
+push/%: ## push the branch and HEAD git SHA tags for a component to Docker Hub
 	docker push $(DHUB_ORG)/$(IMAGE_PREFIX)$(notdir $@):$(BRANCH)
 	docker push $(DHUB_ORG)/$(IMAGE_PREFIX)$(notdir $@):$(GIT_MASTER_HEAD_SHA)
 

--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,13 @@
 # image is named data8/jupyterhub-k8s-<name> where <name> is the name of the
 # component (eg. cull).
 #
+# All pushed are tagged with the SHA of the commit, as well as the name of the
+# current git branch.
+#
 # When creating a new image, first create the repo on Docker Hub under the
 # data8 org. Then, add it to the ALL_IMAGES variable below.
 
-.PHONY: help environment-check
+.PHONY: help
 
 ALL_IMAGES:=cull \
 	hub
@@ -17,6 +20,9 @@ ALL_IMAGES:=cull \
 IMAGE_PREFIX:=jupyterhub-k8s-
 
 DHUB_ORG:=data8
+
+# Get current branch name
+BRANCH:=$(shell git symbolic-ref --short HEAD 2>/dev/null)
 
 # Grabs the SHA of the latest commit for tagging purposes
 GIT_MASTER_HEAD_SHA:=$(shell git rev-parse --short=12 --verify HEAD)
@@ -27,39 +33,33 @@ help:
 	@echo "====================="
 	@grep -E '^[a-zA-Z0-9_%/-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
 
-# This is a simple check that is used to prevent accidental pushes since
-# Travis should be building our images.
-environment-check:
-	test -e ~/.jhub-k8s-images-builder
-
-refresh/%: ## pull the latest image from Docker Hub for a stack
-# skip if error: a stack might not be on dockerhub yet
-	-docker pull $(DHUB_ORG)/$(IMAGE_PREFIX)$(notdir $@):latest
+refresh/%: ## pull the latest image from Docker Hub
+# skip if error: an image might not be on dockerhub yet
+	-docker pull $(DHUB_ORG)/$(IMAGE_PREFIX)$(notdir $@):$(BRANCH)
 
 refresh-all: $(ALL_IMAGES:%=refresh/%) ## refresh all images
 
 build/%: DARGS?=
 build/%: ## build the latest image for a component
 	docker build $(DARGS) --rm --force-rm \
-		-t $(DHUB_ORG)/$(IMAGE_PREFIX)$(notdir $@):latest \
+		-t $(DHUB_ORG)/$(IMAGE_PREFIX)$(notdir $@):$(BRANCH) \
 		./$(notdir $@)
 
 build-all: $(ALL_IMAGES:%=build/%) ## build all images
 
 tag/%: ## tag the latest component image with the HEAD git SHA
-	docker tag $(DHUB_ORG)/$(IMAGE_PREFIX)$(notdir $@):latest \
+	docker tag $(DHUB_ORG)/$(IMAGE_PREFIX)$(notdir $@):$(BRANCH) \
 		$(DHUB_ORG)/$(IMAGE_PREFIX)$(notdir $@):$(GIT_MASTER_HEAD_SHA)
 
 tag-all: $(ALL_IMAGES:%=tag/%) ## tag all images
 
 push/%: ## push the latest and HEAD git SHA tags for a component to Docker Hub
-	docker push $(DHUB_ORG)/$(IMAGE_PREFIX)$(notdir $@):latest
+	docker push $(DHUB_ORG)/$(IMAGE_PREFIX)$(notdir $@):$(BRANCH)
 	docker push $(DHUB_ORG)/$(IMAGE_PREFIX)$(notdir $@):$(GIT_MASTER_HEAD_SHA)
 
 push-all: $(ALL_IMAGES:%=push/%) ## push all images
 
-release-all: environment-check \
-	refresh-all \
+release-all: refresh-all \
 	build-all \
 	tag-all \
 	push-all

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -24,28 +24,28 @@ kind: Deployment
 metadata:
   name: hub-proxy-deployment
 spec:
-    replicas: 1
-    template:
-      metadata:
-        labels:
-          name: hub-proxy-pod
-      spec:
-        containers:
-        - name: hub-proxy-container
-          image: data8/jupyterhub-k8s-hub:latest
-          env:
-          - name: POD_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-          - name: CULL_JHUB_TOKEN
-            valueFrom:
-              configMapKeyRef:
-                name: cull-config
-                key: auth.jhub-token.cull
-          ports:
-            - containerPort: 8000
-              name: hub-proxy-port
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: hub-proxy-pod
+    spec:
+      containers:
+      - name: hub-proxy-container
+        image: data8/jupyterhub-k8s-hub:master
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CULL_JHUB_TOKEN
+          valueFrom:
+            configMapKeyRef:
+              name: cull-config
+              key: auth.jhub-token.cull
+        ports:
+          - containerPort: 8000
+            name: hub-proxy-port
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -60,7 +60,7 @@ spec:
     spec:
       containers:
         - name: cull-container
-          image: data8/jupyterhub-k8s-cull:latest
+          image: data8/jupyterhub-k8s-cull:master
           command:
             - /bin/sh
             - -c


### PR DESCRIPTION
@derrickmar @SaladRaider @allanlwu @jiefugong 

Before, all images are pushed with the SHA and the `latest` tag.

With this commit, pushing an image will tag it with the branch name as
well for easier use while developing.

Unfortunately, k8s doesn't support templating yet
(https://github.com/kubernetes/kubernetes/issues/23896) so you'll still
have to manually change the image tag in the `manifest.yaml` file back
and forth but it's definitely easier than before.

Now, the workflow is:

1. Work on image
2. Push with `make release-all`
3. Edit `manifest.yaml` to use images for your branch to test
4. Edit it back when making a PR.