### PR TITLE
Persistent hub disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,34 @@ Returns output that looks like:
 
     Kubernetes master is running at https://146.148.80.79
 
+In our configuartion, we also rely on persistent disks created by the Google Cloud Platform for storage. You may provision a disk on the Google Cloud Shell using the following command:
+	
+	gcloud compute disk create your-disk-name-here --size 10GiB
+
+Please note that you will need to use the name of the disk you created, and that the size of the disk may vary based on your use case. The hub uses a disk of size 10 gigabytes.  
+
+Once you run the above command, you will be prompted for the region you want to create your disk at. Please select:
+
+	[10] us-central1-a
+
+Now, change your manifest.yaml file such that in the entry for PersistentVolume:
+
+	kind: PersistentVolume
+	metadata:
+		name: your-disk-name-here
+	...
+	gcePersistentDisk:
+		pdName: your-disk-name-here
+		fsType: ext4
+
+Lastly, change your PersistentVolumeClaim entry to request the same amount of storage as you provisioned for your disk. For us, it looks like this:
+	
+	kind: PersistentVolumeClaim
+	...
+	resources:
+		requests:
+			storage: 10Gi
+
 Then, from the project root, run
 
     kubectl apply -f manifest.yaml

--- a/README.md
+++ b/README.md
@@ -30,11 +30,7 @@ We also rely on persistent disks created by the Google Cloud Platform.
 
 You may provision a disk on the Google Cloud Shell using the following command:
     
-    gcloud compute disk create your-disk-name-here --size 10GiB
-
-Then, select the region you want to create your disk at when prompted, using:
-
-    [10] us-central1-a
+    gcloud compute disks create your-disk-name-here --size 10GiB
 
 Now, change your manifest file such that in the entry for PersistentVolume:
 

--- a/README.md
+++ b/README.md
@@ -26,33 +26,33 @@ Returns output that looks like:
 
     Kubernetes master is running at https://146.148.80.79
 
-In our configuartion, we also rely on persistent disks created by the Google Cloud Platform for storage. You may provision a disk on the Google Cloud Shell using the following command:
-	
-	gcloud compute disk create your-disk-name-here --size 10GiB
+We also rely on persistent disks created by the Google Cloud Platform. 
 
-Please note that you will need to use the name of the disk you created, and that the size of the disk may vary based on your use case. The hub uses a disk of size 10 gigabytes.  
+You may provision a disk on the Google Cloud Shell using the following command:
+    
+    gcloud compute disk create your-disk-name-here --size 10GiB
 
-Once you run the above command, you will be prompted for the region you want to create your disk at. Please select:
+Then, select the region you want to create your disk at when prompted, using:
 
-	[10] us-central1-a
+    [10] us-central1-a
 
-Now, change your manifest.yaml file such that in the entry for PersistentVolume:
+Now, change your manifest file such that in the entry for PersistentVolume:
 
-	kind: PersistentVolume
-	metadata:
-		name: your-disk-name-here
-	...
-	gcePersistentDisk:
-		pdName: your-disk-name-here
-		fsType: ext4
+    kind: PersistentVolume
+    metadata:
+        name: your-disk-name-here
+    ...
+    gcePersistentDisk:
+        pdName: your-disk-name-here
+        fsType: ext4
 
-Lastly, change your PersistentVolumeClaim entry to request the same amount of storage as you provisioned for your disk. For us, it looks like this:
-	
-	kind: PersistentVolumeClaim
-	...
-	resources:
-		requests:
-			storage: 10Gi
+Lastly, change your PersistentVolumeClaim entry to reflect disk size:
+    
+    kind: PersistentVolumeClaim
+    ...
+    resources:
+        requests:
+            storage: 10Gi
 
 Then, from the project root, run
 

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -29,7 +29,7 @@ data:
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: data8-hub-workdir
+  name: data8-hub-workdir-01
 spec:
   capacity:
     storage: 1Gi
@@ -37,7 +37,7 @@ spec:
     - ReadWriteOnce
   persistentVolumeReclaimPolicy: Retain
   gcePersistentDisk:
-    pdName: data8-hub-workdir
+    pdName: data8-hub-workdir-01
     fsType: ext4
 ---
 kind: PersistentVolumeClaim

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,3 +1,23 @@
+#
+# We are using a GCE disk as persistent storage for the Hub
+# and eventually, each individual user node.
+#
+# An administrator with access must provision these disks with a reasonable amount of space
+# before hand. Please note that with the K8s deployment, we are no longer using a shared NFS
+# and instead each user will have his or her own disk.
+# 
+# Find the region for your cluster beforehand using:
+#
+#     gcloud container clusters list
+#
+# Provision your disk like so:
+#
+#     gcloud compute disks create hub-workdir-01 --size 1GiB
+#
+# Please make sure to delete your disk after you are done using it as you will be charged.
+#
+#     gcloud compute disks delete hub-workdir-01
+
 kind: ConfigMap
 apiVersion: v1
 metadata:
@@ -5,6 +25,31 @@ metadata:
 data:
   # Used to authenticate the culler to the hub. This string was generated with `openssl rand -hex 32`.
   auth.jhub-token.cull: 13fdff1305cd883e49223908186a63294922dadb59b5d1122473041f160c4b03
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: data8-hub-workdir
+spec:
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  gcePersistentDisk:
+    pdName: data8-hub-workdir
+    fsType: ext4
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: data8-workdir
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
 ---
 apiVersion: v1
 kind: Service
@@ -30,9 +75,16 @@ spec:
       labels:
         name: hub-proxy-pod
     spec:
+      volumes:
+      - name: data8-workdir-volume
+        persistentVolumeClaim:
+          claimName: data8-workdir
       containers:
       - name: hub-proxy-container
         image: data8/jupyterhub-k8s-hub:master
+        volumeMounts:
+          - mountPath: /srv/jupyterhub
+            name: data8-workdir-volume
         env:
         - name: POD_NAMESPACE
           valueFrom:

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -49,7 +49,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 1Gi
+      storage: 10Gi
 ---
 apiVersion: v1
 kind: Service

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -32,7 +32,7 @@ metadata:
   name: data8-hub-workdir-01
 spec:
   capacity:
-    storage: 1Gi
+    storage: 10Gi
   accessModes:
     - ReadWriteOnce
   persistentVolumeReclaimPolicy: Retain


### PR DESCRIPTION
- Added 10G disk in Google Cloud for Hub
- Changed manifest file to use said disk
- Tested on Google Cloud Deployment, can obtain disk, information retained even as nodes are destroyed and restarted
- README.md updated to inform users on how to perform these steps