### PR TITLE
Changed storage to 10Gi instead of 10GiB

### DIFF
--- a/hub/jupyterhub_config.py
+++ b/hub/jupyterhub_config.py
@@ -17,7 +17,7 @@ c.KubeSpawner.singleuser_image_spec = 'yuvipanda/simple-singleuser:v1'
 c.KubeSpawner.pvc_name_template = 'claim-{username}-{userid}'
 c.KubeSpawner.storage_class = 'single-user-storage'
 c.KubeSpawner.access_modes = ['ReadWriteOnce']
-c.KubeSpawner.storage = '10GiB'
+c.KubeSpawner.storage = '10Gi'
 
 # Add volumes to singleuser pods
 c.KubeSpawner.volumes = [


### PR DESCRIPTION
Summary
-------
Fixes jupyterhub_config.py storage setting to use "10Gi" instead of "10GiB"

How to test
-------
1. Log into JupyterHub as user `sam`
2. Verify that the Start Server button is present.
3. Press "Start Server"
4. Wait until you are redirected to your notebook
5. Make a file in "home/"
6. Click "Control Panel"
7. Click "Stop My Server"
8. Run `kubectl get pods` to ensure the pod has exited.
9. Click "Start Server" to start your pod again.
10. Navigate back to "home/"
11. The file you created should be still there in "home/"

