### PR TITLE
Change hub pvc to use StorageClass so admin does not have manually pr…

### DIFF
--- a/hub/jupyterhub_config.py
+++ b/hub/jupyterhub_config.py
@@ -15,7 +15,7 @@ c.KubeSpawner.singleuser_image_spec = 'yuvipanda/simple-singleuser:v1'
 
 # Configure dynamically provisioning pvc
 c.KubeSpawner.pvc_name_template = 'claim-{username}-{userid}'
-c.KubeSpawner.storage_class = 'single-user-storage'
+c.KubeSpawner.storage_class = 'gce-standard-storage'
 c.KubeSpawner.access_modes = ['ReadWriteOnce']
 c.KubeSpawner.storage = '10Gi'
 

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,22 +1,10 @@
 #
 # We are using a GCE disk as persistent storage for the Hub
-# and eventually, each individual user node.
+# and for each individual user node.
 #
-# An administrator with access must provision these disks with a reasonable amount of space
-# before hand. Please note that with the K8s deployment, we are no longer using a shared NFS
-# and instead each user will have his or her own disk.
-#
-# Find the region for your cluster beforehand using:
-#
-#     gcloud container clusters list
-#
-# Provision your disk like so:
-#
-#     gcloud compute disks create hub-workdir-01 --size 1GiB
-#
-# Please make sure to delete your disk after you are done using it as you will be charged.
-#
-#     gcloud compute disks delete hub-workdir-01
+# An administrator no longer has to manually provision a disk for the Hub.
+# Since the pvc for the hub is using a storage class, the volume will automatically
+# be provisioned dynamically
 
 kind: StorageClass
 apiVersion: storage.k8s.io/v1beta1
@@ -35,24 +23,12 @@ data:
   # Used to authenticate the culler to the hub. This string was generated with `openssl rand -hex 32`.
   auth.jhub-token.cull: 13fdff1305cd883e49223908186a63294922dadb59b5d1122473041f160c4b03
 ---
-apiVersion: v1
-kind: PersistentVolume
-metadata:
-  name: data8-hub-workdir-01
-spec:
-  capacity:
-    storage: 10Gi
-  accessModes:
-    - ReadWriteOnce
-  persistentVolumeReclaimPolicy: Retain
-  gcePersistentDisk:
-    pdName: data8-hub-workdir-01
-    fsType: ext4
----
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: data8-workdir
+  annotations:
+    volume.beta.kubernetes.io/storage-class: single-user-storage
 spec:
   accessModes:
     - ReadWriteOnce

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -2,14 +2,19 @@
 # We are using a GCE disk as persistent storage for the Hub
 # and for each individual user node.
 #
-# An administrator no longer has to manually provision a disk for the Hub.
-# Since the pvc for the hub is using a storage class, the volume will automatically
-# be provisioned dynamically
+# A volume for the hub is automatically provisioned b/c its pvc
+# is using a storage class. There is no need to manually provision
+# any disks on the cluster.
+# 
+# When a single user pod is spun up, a corresponding pvc is 
+# dynamically provisioned by kubespawner. If a pvc for that user
+# already exists, the pod mounts to the existing pvc.
+# 
 
 kind: StorageClass
 apiVersion: storage.k8s.io/v1beta1
 metadata:
-  name: single-user-storage
+  name: gce-standard-storage
 provisioner: kubernetes.io/gce-pd
 parameters:
   type: pd-standard
@@ -28,7 +33,7 @@ apiVersion: v1
 metadata:
   name: data8-workdir
   annotations:
-    volume.beta.kubernetes.io/storage-class: single-user-storage
+    volume.beta.kubernetes.io/storage-class: gce-standard-storage
 spec:
   accessModes:
     - ReadWriteOnce


### PR DESCRIPTION
Summary
-------
The hub disk will now be automatically provisioned by using the k8s StorageClass. This will allow the admin to not have to manually provision any disks.

How to test
-------
1. Log into JupyterHub as user `sam`
2. Take note of the id that `sam` has by calling `kubectl get pods`
3. Logout
4. Log into JupyterHub again as a different user, say `peter`
5. Take not of the id of `peter` by calling `kubectl get pods`
6. Logout
7. Delete the deployment by calling `kubectl delete deployments --all`
8. Wait for all the pods to terminate with `watch kubectl get pods`
9. Apply the manifest again with `kubectl apply -f manifest.yaml`
10. Log in as `peter`
11. Get id of `peter` by calling `kubectl get pods`
12. Make sure that the id is the same id that `peter` had before