### PR TITLE
Rename pvc props

### DIFF
--- a/hub/Dockerfile
+++ b/hub/Dockerfile
@@ -7,7 +7,7 @@ RUN pip3 install --upgrade pip
 
 RUN pip3 --no-cache-dir install jupyterhub requests-futures jupyterhub-dummyauthenticator
 
-RUN pip3 --no-cache-dir install git+https://github.com/data-8/kubespawner.git@volumes
+RUN pip3 --no-cache-dir install git+https://github.com/jupyterhub/kubespawner.git
 RUN pip3 --no-cache-dir install git+https://github.com/yuvipanda/jupyterhub-nginx-chp.git
 
 ADD jupyterhub_config.py /srv/jupyterhub_config.py

--- a/hub/Dockerfile
+++ b/hub/Dockerfile
@@ -5,7 +5,8 @@ RUN apt-get install -y --no-install-recommends python3 python3-pip ca-certificat
 
 RUN pip3 install --upgrade pip
 
-RUN pip3 --no-cache-dir install jupyterhub requests-futures jupyterhub-dummyauthenticator
+RUN pip3 install --no-cache-dir --pre jupyterhub
+RUN pip3 --no-cache-dir install requests-futures jupyterhub-dummyauthenticator
 
 RUN pip3 --no-cache-dir install git+https://github.com/jupyterhub/kubespawner.git
 RUN pip3 --no-cache-dir install git+https://github.com/yuvipanda/jupyterhub-nginx-chp.git

--- a/hub/jupyterhub_config.py
+++ b/hub/jupyterhub_config.py
@@ -21,9 +21,9 @@ c.KubeSpawner.singleuser_image_spec = 'yuvipanda/simple-singleuser:v1'
 
 # Configure dynamically provisioning pvc
 c.KubeSpawner.pvc_name_template = 'claim-{username}-{userid}'
-c.KubeSpawner.storage_class = 'gce-standard-storage'
-c.KubeSpawner.access_modes = ['ReadWriteOnce']
-c.KubeSpawner.storage = '10Gi'
+c.KubeSpawner.user_storage_class = 'gce-standard-storage'
+c.KubeSpawner.user_storage_access_modes = ['ReadWriteOnce']
+c.KubeSpawner.user_storage_capacity = '10Gi'
 
 # Add volumes to singleuser pods
 c.KubeSpawner.volumes = [


### PR DESCRIPTION
Summary
-------
Uses the KubeSpawner from the jupyterhub repo. Changed the KubeSpawner property variable names to the proper ones that are in the updated jupyterhub/kubespawner repo. Now uses the most updated version of jupyterhub b/c the KubeSpawner does not declare certain properties like `mem_limit` anymore since it assumes they already exist in the Spawner class in the upstream jupyterhub repo.

How to test
-------
1. Log into JupyterHub as user `sam`
2. Verify that the Start Server button is present.
3. Press "Start Server"
4. Wait until you are redirected to your notebook
5. Make a file in "home/"
6. Click "Control Panel"
7. Click "Stop My Server"
8. Run `kubectl get pods` to ensure the pod has exited.
9. Click "Start Server" to start your pod again.
10. Navigate back to "home/"
11. The file you created should be still there in "home/"
