### PR TITLE
Add release/<image> for convenience to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,8 +64,7 @@ release/%: ## release a particular image name
 	tag/$(notdir $@) \
 	push/$(notdir $@)
 
-release-all: refresh-all \
-	build-all \
+release-all: build-all \
 	tag-all \
 	push-all
 release-all: ## build, tag, and push all images

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,11 @@ push/%: ## push the branch and HEAD git SHA tags for a component to Docker Hub
 
 push-all: $(ALL_IMAGES:%=push/%) ## push all images
 
+release/%: ## release a particular image name
+	$(MAKE) build/$(notdir $@) \
+	tag/$(notdir $@) \
+	push/$(notdir $@)
+
 release-all: refresh-all \
 	build-all \
 	tag-all \


### PR DESCRIPTION
Summary
-------
Allows you to specify only a specific image to release.
I also removed ```refresh-all``` from ```release-all``` because I think in most cases you already have the cache stored locally and pulling from docker hub usually takes longer.

How to test
-------
Run `make release/hub` and you will see on hub being built, tagged, and pushed 