### PR TITLE
Add separate proxy container to repo

### DIFF
--- a/hub/Dockerfile
+++ b/hub/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:jessie
 
 RUN apt-get update
-RUN apt-get install -y --no-install-recommends python3 python3-pip ca-certificates git nginx-extras lua-cjson
+RUN apt-get install -y --no-install-recommends python3 python3-pip ca-certificates git
 
 RUN pip3 install --upgrade pip
 
@@ -9,7 +9,6 @@ RUN pip3 install --no-cache-dir --pre jupyterhub
 RUN pip3 install oauthenticator==0.4.*
 
 RUN pip3 --no-cache-dir install git+https://github.com/derrickmar/kubespawner
-RUN pip3 --no-cache-dir install git+https://github.com/yuvipanda/jupyterhub-nginx-chp.git
 
 ADD jupyterhub_config.py /srv/jupyterhub_config.py
 

--- a/hub/jupyterhub_config.py
+++ b/hub/jupyterhub_config.py
@@ -8,7 +8,6 @@ c.JupyterHub.spawner_class = 'kubespawner.KubeSpawner'
 # Connect to a proxy running in a different pod
 c.JupyterHub.proxy_api_ip = os.environ['PROXY_API_SERVICE_HOST']
 c.JupyterHub.proxy_api_port = int(os.environ['PROXY_API_SERVICE_PORT'])
-c.JupyterHub.proxy_cmd = '/usr/local/bin/nchp'
 
 c.JupyterHub.ip = os.environ['PROXY_PUBLIC_SERVICE_HOST']
 c.JupyterHub.port = int(os.environ['PROXY_PUBLIC_SERVICE_PORT'])

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -1,0 +1,21 @@
+FROM debian:jessie
+
+# We need this for an nginx that's new enough
+RUN echo 'deb http://ftp.debian.org/debian jessie-backports main' >> /etc/apt/sources.list
+
+RUN apt-get update
+
+RUN apt-get install --yes --no-install-recommends -t jessie-backports\
+    ca-certificates \
+    nginx-extras \
+    git \
+    python3-pip \
+    curl \
+    lua-cjson
+
+RUN pip3 install jinja2 traitlets
+RUN pip3 install git+https://github.com/yuvipanda/jupyterhub-nginx-chp.git@master#egg=nchp
+
+EXPOSE 8000
+
+CMD /usr/local/bin/nchp --ip 0.0.0.0 --port 8000 --api-ip 0.0.0.0 --api-port 8001  --default-target http://${HUB_SERVICE_HOST}:${HUB_SERVICE_PORT} 


### PR DESCRIPTION

Summary
-------

- Remove proxy installation from the hub container, since it is not used directly
- Add the Dockerfile used to build the nchp container image

How to test
-------

- Do a deploy, but with a rebuilt nchp container image