### PR TITLE
Explicitly pull singleuser images always

### DIFF
--- a/hub/jupyterhub_config.py
+++ b/hub/jupyterhub_config.py
@@ -20,6 +20,7 @@ c.KubeSpawner.start_timeout = 60 * 20
 
 # Our simplest user image! Optimized to just... start, and be small!
 c.KubeSpawner.singleuser_image_spec = os.environ['SINGLEUSER_IMAGE']
+c.KubeSpawner.singleuser_image_pull_policy = 'Always'
 
 # Configure dynamically provisioning pvc
 c.KubeSpawner.pvc_name_template = 'claim-{username}-{userid}'


### PR DESCRIPTION
Explicitly pull all singleuser images before running - do not rely on :latest to do that.

We should migrate to explicit tags later