### PR TITLE
Pre-generate font cache in a non $HOME location

### DIFF
--- a/user/Dockerfile
+++ b/user/Dockerfile
@@ -90,7 +90,8 @@ RUN wget -q -P /usr/share/fonts \
 
 # Pre-generate font cache so the user does not see fc-list warning when
 # importing datascience. https://github.com/matplotlib/matplotlib/issues/5836
-# RUN python -c 'import matplotlib.pyplot'
+# When run as root, this generates them in /var/cache/fontconfig, and not under $HOME
+RUN python -c 'import matplotlib.pyplot'
 
 #######################################################################
 


### PR DESCRIPTION
Running this as root puts them in `/var/cache/fontconfig` and not under $HOME,
which is important since $HOME is mounted over by our persistent volume.