### PR TITLE
Stack containers

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,9 @@
+# Docker Containers
+
+## Guidelines
+
+Derived images can only change the following:
+
+1. Set new environment variables
+1. Add conda, pip, and apt packages
+1. Add jupyter extensions

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,5 +1,10 @@
 # Docker Containers
 
+Using a stack of derived containers allows us to:
+
+1. Disable caching, which should reliably pick up changes in the build scripts
+1. Realize quicker build times
+
 ## Guidelines
 
 Derived images can only change the following:

--- a/user/Dockerfile
+++ b/user/Dockerfile
@@ -1,0 +1,104 @@
+# This container image will be used by students with JupyterHub
+# It is organized in the following fashion:
+#
+#  - Install base packages (useful for everyone) with apt-get
+#  - Setup environment variables (particularly locales) that will
+#    affect most programs
+#  - Setup the user that users will be running as
+#  - Install miniconda
+#  - Install base packages (notebook, jupyterhub)
+#  - Install any packages with specific data needs (such as NLTK)
+#  - Install pip packages
+#  - Install miniconda packages
+#  - Install various notebook extensions
+#
+# Since we'll be mounting /home/jovyan from a persistent volume,
+# anything you add in the docker file under /home/jovyan will
+# never take effect.
+
+FROM debian:jessie
+
+MAINTAINER Derrick Mar <derrickmar1215@berkeley.edu>
+
+# Install all OS dependencies for notebook server that starts but lacks all
+# features (e.g., download as all possible file formats)
+RUN apt-get update
+ADD install-base-apt.bash /usr/local/sbin/install-base-apt.bash
+RUN /usr/local/sbin/install-base-apt.bash
+
+# Generate the en_US UTF-8 Locale, and set that to be
+# the default locale. Otherwise it'll default to the 8bit C
+# locale, and cause problems any time we use characters that
+# are not 8-bit ASCII.
+RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && locale-gen
+ENV LC_ALL en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US.UTF-8
+
+# Set the default shell to bash, rather than sh
+ENV SHELL /bin/bash
+
+# Configure Environment
+ENV CONDA_DIR /opt/conda
+ENV PATH $CONDA_DIR/bin:$PATH
+ENV NB_USER jovyan
+ENV NB_UID 1000
+
+# Since we put NLTK data in /opt rather than /usr/local,
+# we have to explicitly set this
+ENV NLTK_DATA ${CONDA_DIR}/nltk
+
+# We want to pre-generate the matplotlib font-list cache
+# in a way that keeps the cache in the docker image (since
+# $HOME is mounted in a persistent volume). We do this by
+# making matplotlib keep its cache (and other config too - but
+# we don't care about that for now) in /var/cache by setting
+# the environment variable MPLCONFIGDIR. We then import
+# matplotlib's pyplot later to trigger this caching behavior.
+# NOTE: This can be done away with once we use MPL 2
+ENV MPLCONFIGDIR=/var/cache/matplotlib
+
+# Create a jovyan user with UID 1000. It also automatically
+# creates a group with GID 1000 named jovyan
+RUN adduser --gecos '' --shell /bin/bash --uid $NB_UID --disabled-password $NB_USER 
+
+# Install conda into $CONDA_DIR, and chown it to $NB_USER
+ADD install-conda.bash /usr/local/sbin/install-conda.bash
+RUN /usr/local/sbin/install-conda.bash
+
+# Install packages that we use for pdf / publishing related
+# things.
+ADD install-publishing-apt.bash /usr/local/sbin/install-publishing-apt.bash
+RUN /usr/local/sbin/install-publishing-apt.bash
+
+# Ensure LaTeX buffer is large enough
+RUN echo buf_size=6400000 > /etc/texmf/texmf.d/10data8.cnf
+RUN update-texmf
+
+# Download XKCD font for plt.xkcd()
+RUN wget -q -P /usr/share/fonts \
+  https://github.com/shreyankg/xkcd-desktop/raw/master/Humor-Sans.ttf
+
+# Create matplotlib font-list cache dir
+RUN install -d -o $NB_USER -g $NB_USER $MPLCONFIGDIR
+
+USER $NB_USER
+
+ADD install-base-notebook.bash /usr/local/sbin/install-base-notebook.bash
+RUN /usr/local/sbin/install-base-notebook.bash
+
+ADD install-python-packages.bash /usr/local/sbin/install-python-packages.bash
+
+#######################################################################
+
+EXPOSE 8888
+WORKDIR /home/$NB_USER
+
+CMD jupyterhub-singleuser \
+  --port=8888 \
+  --ip=0.0.0.0 \
+  --user="$JPY_USER" \
+  --cookie-name=$JPY_COOKIE_NAME \
+  --base-url=$JPY_BASE_URL \
+  --hub-prefix=$JPY_HUB_PREFIX \
+  --hub-api-url=$JPY_HUB_API_URL

--- a/user/Dockerfile.base
+++ b/user/Dockerfile.base
@@ -12,12 +12,6 @@
 #  - Install miniconda packages
 #  - Install various notebook extensions
 #
-# We also split things into separate bash scripts that are
-# then run from inside the container, rather than super long
-# single lines with && in Docker. This is cleaner to understand
-# and maintain in the long run. We trade off some docker build
-# time cache for this, but gain in clarity and maintainability.
-#
 # Since we'll be mounting /home/jovyan from a persistent volume,
 # anything you add in the docker file under /home/jovyan will
 # never take effect.
@@ -50,6 +44,20 @@ ENV PATH $CONDA_DIR/bin:$PATH
 ENV NB_USER jovyan
 ENV NB_UID 1000
 
+# Since we put NLTK data in /opt rather than /usr/local,
+# we have to explicitly set this
+ENV NLTK_DATA ${CONDA_DIR}/nltk
+
+# We want to pre-generate the matplotlib font-list cache
+# in a way that keeps the cache in the docker image (since
+# $HOME is mounted in a persistent volume). We do this by
+# making matplotlib keep its cache (and other config too - but
+# we don't care about that for now) in /var/cache by setting
+# the environment variable MPLCONFIGDIR. We then import
+# matplotlib's pyplot later to trigger this caching behavior.
+# NOTE: This can be done away with once we use MPL 2
+ENV MPLCONFIGDIR=/var/cache/matplotlib
+
 # Create a jovyan user with UID 1000. It also automatically
 # creates a group with GID 1000 named jovyan
 RUN adduser --gecos '' --shell /bin/bash --uid $NB_UID --disabled-password $NB_USER 
@@ -63,23 +71,6 @@ RUN /usr/local/sbin/install-conda.bash
 ADD install-publishing-apt.bash /usr/local/sbin/install-publishing-apt.bash
 RUN /usr/local/sbin/install-publishing-apt.bash
 
-USER $NB_USER
-
-ADD install-base-notebook.bash /usr/local/sbin/install-base-notebook.bash
-RUN /usr/local/sbin/install-base-notebook.bash
-
-ADD install-python-packages.bash /usr/local/sbin/install-python-packages.bash
-ADD connectors /usr/local/sbin/connectors-setup
-RUN /usr/local/sbin/install-python-packages.bash
-
-# Since we put NLTK data in /opt rather than /usr/local,
-# we have to explicitly set this
-ENV NLTK_DATA ${CONDA_DIR}/nltk
-
-ADD install-extensions.bash /usr/local/sbin/install-extensions.bash
-RUN /usr/local/sbin/install-extensions.bash
-
-USER root
 # Ensure LaTeX buffer is large enough
 RUN echo buf_size=6400000 > /etc/texmf/texmf.d/10data8.cnf
 RUN update-texmf
@@ -88,17 +79,16 @@ RUN update-texmf
 RUN wget -q -P /usr/share/fonts \
   https://github.com/shreyankg/xkcd-desktop/raw/master/Humor-Sans.ttf
 
-# We want to pre-generate the matplotlib font-list cache
-# in a way that keeps the cache in the docker image (since
-# $HOME is mounted in a persistent volume). We do this by
-# making matplotlib keep its cache (and other config too - but
-# we don't care about that for now) in /var/cache by setting
-# the environment variable MPLCONFIGDIR. We then import
-# matplotlib's pyplot to trigger this caching behavior.
-# NOTE: This can be done away with once we use MPL 2
-RUN mkdir -p /var/cache/matplotlib && chown jovyan:jovyan /var/cache/matplotlib
-ENV MPLCONFIGDIR=/var/cache/matplotlib
-RUN MPLBACKEND=nbagg python -c 'import matplotlib.pyplot'
+# Create matplotlib font-list cache dir
+RUN install -d -o $NB_USER -g $NB_USER $MPLCONFIGDIR
+
+USER $NB_USER
+
+ADD install-base-notebook.bash /usr/local/sbin/install-base-notebook.bash
+RUN /usr/local/sbin/install-base-notebook.bash
+
+ADD install-python-packages.bash /usr/local/sbin/install-python-packages.bash
+
 #######################################################################
 
 EXPOSE 8888
@@ -112,4 +102,3 @@ CMD jupyterhub-singleuser \
   --base-url=$JPY_BASE_URL \
   --hub-prefix=$JPY_HUB_PREFIX \
   --hub-api-url=$JPY_HUB_API_URL
-

--- a/user/Dockerfile.datahub
+++ b/user/Dockerfile.datahub
@@ -1,0 +1,22 @@
+# This container image will be used by students with JupyterHub
+#
+# We split things into separate bash scripts that are then run from inside
+# the container, rather than super long single lines with && in Docker.
+# This is cleaner to understand and maintain in the long run. We trade off
+# some docker build time cache for this, but gain in clarity and
+# maintainability.
+#
+# Since we'll be mounting /home/jovyan from a persistent volume, anything
+# you add in the docker file under /home/jovyan will never take effect.
+
+FROM gcr.io/data-8/singleuser-base
+
+MAINTAINER Data Science Infrastructure <ds-inst@berkeley.edu>
+
+USER $NB_USER
+
+ADD connectors /usr/local/sbin/connectors-setup
+RUN /usr/local/sbin/install-python-packages.bash
+
+ADD install-extensions.bash /usr/local/sbin/install-extensions.bash
+RUN /usr/local/sbin/install-extensions.bash

--- a/user/Dockerfile.stat28
+++ b/user/Dockerfile.stat28
@@ -1,0 +1,13 @@
+FROM gcr.io/data-8/singleuser-datahub:latest
+
+MAINTAINER Ryan Lovett <rylo@berkeley.edu>
+
+USER root
+
+ADD install-rstudio-server.bash /usr/local/sbin/install-rstudio-server.bash
+RUN /usr/local/sbin/install-rstudio-server.bash
+
+USER $NB_USER
+
+ADD install-nbrsessionproxy.bash /usr/local/sbin/install-nbrsessionproxy.bash
+RUN /usr/local/sbin/install-nbrsessionproxy.bash

--- a/user/install-nbrsessionproxy.bash
+++ b/user/install-nbrsessionproxy.bash
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# nbrsessionproxy notebook extension
+${CONDA_DIR}/bin/pip install -U --no-deps \
+    git+https://github.com/ryanlovett/nbrsessionproxy.git@v0.1.5
+${CONDA_DIR}/bin/jupyter serverextension enable --sys-prefix --py nbrsessionproxy
+${CONDA_DIR}/bin/jupyter nbextension install    --sys-prefix --py nbrsessionproxy
+${CONDA_DIR}/bin/jupyter nbextension enable     --sys-prefix --py nbrsessionproxy

--- a/user/install-rstudio-server.bash
+++ b/user/install-rstudio-server.bash
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e
+
+VERSION=1.0.136
+URL="https://download2.rstudio.org/rstudio-server-${VERSION}-amd64.deb"
+PACKAGE="$(basename ${URL})"
+
+apt-get update
+apt-get -y --quiet --no-install-recommends install \
+    gdebi-core \
+    r-base \
+    r-base-dev \
+    libopenblas-base
+
+wget --quiet ${URL}
+gdebi --non-interactive ${PACKAGE}
+rm ${PACKAGE}
+
+apt-get clean


### PR DESCRIPTION
Using a stack of derived containers allows us to:

1. Disable caching, which should reliably pick up changes in the build scripts
1. Realize quicker build times