### PR TITLE
Update Google Drive NBExtension hash

### DIFF
--- a/user/install-extensions.bash
+++ b/user/install-extensions.bash
@@ -26,7 +26,7 @@ ${CONDA_DIR}/bin/jupyter serverextension enable --sys-prefix --py nbinteract
 ${CONDA_DIR}/bin/jupyter nbextension install --sys-prefix --py nbinteract
 ${CONDA_DIR}/bin/jupyter nbextension enable --sys-prefix --py nbinteract
 
-${CONDA_DIR}/bin/pip install git+https://github.com/data-8/nbgdrive.git
+${CONDA_DIR}/bin/pip install git+https://github.com/data-8/nbgdrive.git@3a98798
 ${CONDA_DIR}/bin/jupyter serverextension enable --sys-prefix --py nbgdrive
 ${CONDA_DIR}/bin/jupyter nbextension install --sys-prefix --py nbgdrive
 ${CONDA_DIR}/bin/jupyter nbextension enable --sys-prefix --py nbgdrive


### PR DESCRIPTION
This PR includes NBGdrive changes and is being used only as a test for a sample deployment

Summary
-------
Add hash for GDrive NBExtension to user extension bash script

How to test
-------
1. Log into JupyterHub
2. Verify your Google Drive account against the NBExtension
3. Check that syncing by using the Google Drive sync button displays status text