### PR TITLE
Tune kubespawner to better deal with observed datahub behavior

### DIFF
--- a/hub/Dockerfile
+++ b/hub/Dockerfile
@@ -16,7 +16,7 @@ RUN pip3 install --upgrade pip
 
 RUN pip3 install --no-cache-dir jupyterhub==0.7.2 oauthenticator==0.5.1 jupyterhub-dummyauthenticator==0.1 statsd
 
-RUN pip3 --no-cache-dir install git+https://github.com/jupyterhub/kubespawner@6327b3f
+RUN pip3 --no-cache-dir install git+https://github.com/jupyterhub/kubespawner@941a12e
 
 ADD jupyterhub_config.py /srv/jupyterhub_config.py
 

--- a/hub/Dockerfile
+++ b/hub/Dockerfile
@@ -8,7 +8,7 @@ RUN pip3 install --upgrade pip
 
 RUN pip3 install --no-cache-dir jupyterhub==0.7.2 oauthenticator==0.5.1 jupyterhub-dummyauthenticator==0.1 statsd
 
-RUN pip3 --no-cache-dir install git+https://github.com/jupyterhub/kubespawner@8ff5473401
+RUN pip3 --no-cache-dir install git+https://github.com/jupyterhub/kubespawner@6327b3f
 
 ADD jupyterhub_config.py /srv/jupyterhub_config.py
 

--- a/hub/Dockerfile
+++ b/hub/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:jessie
 
 RUN apt-get update
 
-RUN apt-get install -y --no-install-recommends python3 python3-pip ca-certificates git libcurl4-openssl-dev
+RUN apt-get install -y --no-install-recommends python3 python3-pip ca-certificates git libcurl4-openssl-dev python3-dev build-essential
 
 RUN pip3 install --upgrade pip
 

--- a/hub/Dockerfile
+++ b/hub/Dockerfile
@@ -2,7 +2,15 @@ FROM debian:jessie
 
 RUN apt-get update
 
-RUN apt-get install -y --no-install-recommends python3 python3-pip ca-certificates git libcurl4-openssl-dev python3-dev build-essential
+RUN apt-get install -y --no-install-recommends \
+    build-essential \
+    ca-certificates \
+    git \
+    libcurl4-openssl-dev \
+    libssl-dev \
+    python3 \
+    python3-dev \
+    python3-pip
 
 RUN pip3 install --upgrade pip
 

--- a/hub/Dockerfile
+++ b/hub/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:jessie
 
 RUN apt-get update
 
-RUN apt-get install -y --no-install-recommends python3 python3-pip ca-certificates git
+RUN apt-get install -y --no-install-recommends python3 python3-pip ca-certificates git libcurl4-openssl-dev
 
 RUN pip3 install --upgrade pip
 

--- a/hub/jupyterhub_config.py
+++ b/hub/jupyterhub_config.py
@@ -35,8 +35,9 @@ c.JupyterHub.hub_ip = '0.0.0.0'
 
 c.KubeSpawner.namespace = os.environ.get('POD_NAMESPACE', 'default')
 
-# Upto 15 minutes, first pulls can be really slow because data8 user image is huge
-c.KubeSpawner.start_timeout = 60 * 20
+# Only a minute, since we expect container images to be pre-pulled
+# If they take more than that, they should be considered failed.
+c.KubeSpawner.start_timeout = 60
 
 # Use env var for this, since we want hub to restart when this changes
 c.KubeSpawner.singleuser_image_spec = os.environ['SINGLEUSER_IMAGE']

--- a/hub/jupyterhub_config.py
+++ b/hub/jupyterhub_config.py
@@ -23,6 +23,10 @@ c.JupyterHub.spawner_class = 'kubespawner.KubeSpawner'
 c.JupyterHub.proxy_api_ip = os.environ['PROXY_API_SERVICE_HOST']
 c.JupyterHub.proxy_api_port = int(os.environ['PROXY_API_SERVICE_PORT'])
 
+# Check that the proxy has routes appropriately setup
+# This isn't the best named setting :D
+c.last_activity_interval = 5
+
 c.JupyterHub.ip = os.environ['PROXY_PUBLIC_SERVICE_HOST']
 c.JupyterHub.port = int(os.environ['PROXY_PUBLIC_SERVICE_PORT'])
 

--- a/hub/jupyterhub_config.py
+++ b/hub/jupyterhub_config.py
@@ -25,7 +25,7 @@ c.JupyterHub.proxy_api_port = int(os.environ['PROXY_API_SERVICE_PORT'])
 
 # Check that the proxy has routes appropriately setup
 # This isn't the best named setting :D
-c.last_activity_interval = 5
+c.JupyterHub.last_activity_interval = 5
 
 c.JupyterHub.ip = os.environ['PROXY_PUBLIC_SERVICE_HOST']
 c.JupyterHub.port = int(os.environ['PROXY_PUBLIC_SERVICE_PORT'])


### PR DESCRIPTION
1. Use curl instead of native tornado for making HTTP requests. This is faster and also makes use of connection pooling.
2. Bump max number of client http connections at a time from 10 to 64.
3. Lower the polling interval for checking if the proxy is ok from 5min to 5s
4. Lower the timeout for a server starting from 20min to 1min. So when spawn fails, users can launch again in 1min and not wait 20min