### PR TITLE
Increase timeout for pods  to start

### DIFF
--- a/hub/jupyterhub_config.py
+++ b/hub/jupyterhub_config.py
@@ -35,9 +35,8 @@ c.JupyterHub.hub_ip = '0.0.0.0'
 
 c.KubeSpawner.namespace = os.environ.get('POD_NAMESPACE', 'default')
 
-# Only a minute, since we expect container images to be pre-pulled
-# If they take more than that, they should be considered failed.
-c.KubeSpawner.start_timeout = 60
+# Sometimes disks take a while to attach, so let's keep a not-too-short timeout
+c.KubeSpawner.start_timeout = 5 * 60
 
 # Use env var for this, since we want hub to restart when this changes
 c.KubeSpawner.singleuser_image_spec = os.environ['SINGLEUSER_IMAGE']


### PR DESCRIPTION
This should fix a lot of the 'too many redirects' errors