### PR TITLE
Update prob140 to 0.2.6.0

### DIFF
--- a/user/install-prob140.bash
+++ b/user/install-prob140.bash
@@ -3,5 +3,5 @@
 # prob140 libraries
 ${CONDA_DIR}/bin/pip install -U --no-deps --no-cache-dir \
 	gsExport==0.2.3 \
-	prob140==0.2.5.0 \
+	prob140==0.2.6.0 \
 	;


### PR DESCRIPTION
Updating the prob140 library for the prob140 interact server

Summary
-------
version 0.2.6.0

How to test
-------

Go onto jupyterhub

```python
import prob140
prob140.__version__
```
Should return 0.2.6.0
