### PR TITLE
Revert nbconvert version on Prob140 hub

### DIFF
--- a/user/install-prob140.bash
+++ b/user/install-prob140.bash
@@ -4,4 +4,5 @@
 ${CONDA_DIR}/bin/pip install -U --no-deps --no-cache-dir \
 	gsExport==0.2.3 \
 	prob140==0.2.6.0 \
+	nbconvert=4.3.0 \
 	;


### PR DESCRIPTION
Summary
-------
nbconvert version >= 5 breaks our gradescope pdf file export system. Need to install nbconvert version 4.3.0

How to test
-------

1. Log into JupyterHub
2. In any notebook, run

```python
import nbconvert
nbconvert.__version__
```
Should give you version 4.3.0
