### PR TITLE
Installing rtree for geog88.

### DIFF
--- a/user/connectors/geog88.bash
+++ b/user/connectors/geog88.bash
@@ -4,4 +4,5 @@ ${CONDA_DIR}/bin/pip --no-cache-dir install \
     geopandas==0.2.1 \
     fiona==1.7.4 \
     mplleaflet==0.0.5 \
+    rtree==0.8.3 \
     ;


### PR DESCRIPTION
Adding rtree for geog88, an optional dependency for geopandas. 