### PR TITLE
Installing some geog88 modules with conda instead of pip.

### DIFF
--- a/user/connectors/geog88.bash
+++ b/user/connectors/geog88.bash
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 ${CONDA_DIR}/bin/pip --no-cache-dir install \
-    geopandas==0.2.1 \
     fiona==1.7.4 \
     mplleaflet==0.0.5 \
-    rtree==0.8.3 \
     ;
 
 ${CONDA_DIR}/bin/conda install --quiet --yes \
-    libspatialindex=1.8.5
+    libspatialindex=1.8.5 \
+    rtree=0.8.3 \
+    geopandas=0.2.1


### PR DESCRIPTION
geopandas and rtree modules cannot be imported properly, they're erroring out. Trying to install them using conda instead of pip.