### PR TITLE
Generalized cleanup 0.9

### DIFF
--- a/helm-chart/templates/culler.yaml
+++ b/helm-chart/templates/culler.yaml
@@ -3,7 +3,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: cull-deployment
-  namespace: {{ .Values.name }}
+  {{ if .Values.name }}namespace: {{ .Values.name }} {{ end }}
 spec:
   replicas: 1
   template:

--- a/helm-chart/templates/global.yaml
+++ b/helm-chart/templates/global.yaml
@@ -13,7 +13,7 @@ metadata:
 kind: StorageClass
 apiVersion: storage.k8s.io/v1beta1
 metadata:
-  name: single-user-storage-{{ .Values.name }}
+  name: single-user-storage-{{ default .Release.Namespace .Values.name }}
 provisioner: kubernetes.io/gce-pd
 parameters:
   type: pd-ssd
@@ -23,7 +23,7 @@ parameters:
 kind: StorageClass
 apiVersion: storage.k8s.io/v1beta1
 metadata:
-  name: hub-storage-{{ .Values.name }}
+  name: hub-storage-{{ default .Release.Namespace .Values.name }}
 provisioner: kubernetes.io/gce-pd
 parameters:
   type: pd-ssd

--- a/helm-chart/templates/hub.yaml
+++ b/helm-chart/templates/hub.yaml
@@ -3,9 +3,9 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: hub-db-dir
-  namespace: {{ .Values.name }}
+  namespace: {{ default .Release.Namespace .Values.name }}
   annotations:
-    volume.beta.kubernetes.io/storage-class: hub-storage-{{ .Values.name }}
+    volume.beta.kubernetes.io/storage-class: hub-storage-{{ default .Release.Namespace .Values.name }}
 spec:
   accessModes:
     - ReadWriteOnce
@@ -18,7 +18,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: hub
-  namespace: {{ .Values.name }}
+  {{ if .Values.name }}namespace: {{ .Values.name }} {{ end }}
 spec:
   selector:
     name: hub-pod
@@ -31,7 +31,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: hub-config
-  namespace: {{ .Values.name }}
+  {{ if .Values.name }}namespace: {{ .Values.name }} {{ end }}
 data:
   token.proxy: {{ .Values.token.proxy | quote }}
   {{ if .Values.cull.enabled -}}
@@ -90,7 +90,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: hub-deployment
-  namespace: {{ .Values.name }}
+  {{ if .Values.name }}namespace: {{ .Values.name }} {{ end }}
 spec:
   replicas: 1
   template:

--- a/helm-chart/templates/proxy.yaml
+++ b/helm-chart/templates/proxy.yaml
@@ -14,7 +14,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: proxy-api
-  namespace: {{ .Values.name }}
+  {{ if .Values.name }}namespace: {{ .Values.name }} {{ end }}
 spec:
   selector:
     name: proxy-pod
@@ -27,7 +27,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: proxy-public
-  namespace: {{ .Values.name }}
+  {{ if .Values.name }}namespace: {{ .Values.name }} {{ end }}
 spec:
   type: LoadBalancer
   {{ if .Values.publicIP }}
@@ -44,7 +44,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: proxy-deployment
-  namespace: {{ .Values.name }}
+  {{ if .Values.name }}namespace: {{ .Values.name }} {{ end }}
 spec:
   replicas: 1
   template:

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -25,7 +25,7 @@ hub:
     tag: v0.2
   resources:
     requests:
-      cpu: 0.5
+      cpu: 0.2
       memory: 1Gi
 
 proxy:
@@ -34,8 +34,8 @@ proxy:
     tag: v0.1
   resources:
     requests:
-      cpu: 1
-      memory: 1Gi
+      cpu: 0.3
+      memory: 512Mi
   labels: null
 
 # Set this explicitly if you want to use a static allocated

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -53,7 +53,7 @@ token:
 
 singleuser:
   storage:
-    type: none
+    type: dynamic
     capacity: 10Gi
     homeMountPath: /home/jovyan
     # type: hostPath

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -4,7 +4,8 @@
 
 # Name of this installation. Will be used to create namespace
 # and storageclass. Must be a valid DNS label
-name: 'datahub-dev'
+# HACK: need to get rid of this, purely use --namespace only
+name: null
 
 # Ideally, we should not be creating namespaces in our templates.
 # Helm can create the when you use --namespace, and we should

--- a/hub/jupyterhub_config.py
+++ b/hub/jupyterhub_config.py
@@ -40,7 +40,6 @@ c.KubeSpawner.start_timeout = 5 * 60
 
 # Use env var for this, since we want hub to restart when this changes
 c.KubeSpawner.singleuser_image_spec = os.environ['SINGLEUSER_IMAGE']
-c.KubeSpawner.singleuser_image_pull_policy = 'Always'
 
 # Configure dynamically provisioning pvc
 storage_type = get_config('singleuser.storage.type')


### PR DESCRIPTION
A smaller version of #146, without the potentially problematic kubespawner changes.

1. No need to set 'name:' explicitly in config yaml, although it is respected if set
2. Better defaults for non berkeley uses.
