### PR TITLE
Include tiniest-notebook image in repo + bump version

### DIFF
--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -60,7 +60,7 @@ singleuser:
     # homeHostPathTemplate: /data/project/paws/userhomes/{userid}
   image:
     name: yuvipanda/tiniest-notebook
-    tag: v1
+    tag: v1.1
   cpu:
     limit: null
     guarantee: null

--- a/tiniest-notebook/Dockerfile
+++ b/tiniest-notebook/Dockerfile
@@ -1,0 +1,15 @@
+FROM alpine:3.5
+
+# We install py-zmq from alpine, since installing it from pip requires we have
+# gcc and build tools installed. manylinux1 wheels don't work on / for alpine yet
+RUN apk add --no-cache python3 py-zmq
+
+RUN pip3 install --no-cache-dir notebook ipykernel jupyterhub
+
+CMD ["/usr/bin/jupyter", "notebook", "--ip=0.0.0.0", "--port=8888"]
+
+ENV HOME /home/jovyan
+ENV USER jovyan
+WORKDIR /home/jovyan
+
+EXPOSE 8888

--- a/tiniest-notebook/README.md
+++ b/tiniest-notebook/README.md
@@ -1,0 +1,26 @@
+# Tiniest notebook stack #
+
+This is the tiniest possible docker image that can run a Jupyter Notebook. It
+is primarily meant for demo purposes where speed of pulling is important.
+
+Not recommended for non-demo uses!
+
+## What it gives you
+
+It is based on [Alpine Linux](https://alpinelinux.org/). It uses pip to install
+both the notebook and jupyterhub packages - the latter allows us to use this
+image for single-user servers in Kubernetes / Docker spawners.
+
+You can use pip3 to install packages (with `pip3` or `apk`) as root. There
+are no non-root users provisioned.
+
+## Basic usage
+
+You can run a notebook with:
+
+```
+sudo docker run  -it  --rm  -p 8888:8888 jupyter/tiniest-notebook
+```
+
+The default command is `/usr/bin/jupyter` (not `/usr/local/bin/jupyth`). For
+use with jupyterhub, `/usr/bin/jupyterhub-singleuser` is also available.


### PR DESCRIPTION
Doesn't belong in docker-stacks
