### PR TITLE
Pin Notebook version + Upgrade ipykernel

### DIFF
--- a/user/Dockerfile.datahub
+++ b/user/Dockerfile.datahub
@@ -9,7 +9,7 @@
 # Since we'll be mounting /home/jovyan from a persistent volume, anything
 # you add in the docker file under /home/jovyan will never take effect.
 
-FROM gcr.io/data-8/jupyterhub-k8s-user-base:19ea2b9
+FROM gcr.io/data-8/jupyterhub-k8s-user-base:6138fed
 
 MAINTAINER Data Science Infrastructure <ds-inst@berkeley.edu>
 

--- a/user/Dockerfile.prob140
+++ b/user/Dockerfile.prob140
@@ -1,4 +1,4 @@
-FROM gcr.io/data-8/jupyterhub-k8s-user-datahub:6138fed
+FROM gcr.io/data-8/jupyterhub-k8s-user-datahub:48e4097
 
 MAINTAINER Ryan Lovett <rylo@berkeley.edu>
 

--- a/user/Dockerfile.prob140
+++ b/user/Dockerfile.prob140
@@ -1,4 +1,4 @@
-FROM gcr.io/data-8/jupyterhub-k8s-user-datahub:3ab93b0
+FROM gcr.io/data-8/jupyterhub-k8s-user-datahub:6138fed
 
 MAINTAINER Ryan Lovett <rylo@berkeley.edu>
 

--- a/user/Dockerfile.stat28
+++ b/user/Dockerfile.stat28
@@ -1,4 +1,4 @@
-FROM gcr.io/data-8/jupyterhub-k8s-user-datahub:ef8cebd
+FROM gcr.io/data-8/jupyterhub-k8s-user-datahub:6138fed
 
 MAINTAINER Ryan Lovett <rylo@berkeley.edu>
 

--- a/user/Dockerfile.stat28
+++ b/user/Dockerfile.stat28
@@ -1,4 +1,4 @@
-FROM gcr.io/data-8/jupyterhub-k8s-user-datahub:6138fed
+FROM gcr.io/data-8/jupyterhub-k8s-user-datahub:48e4097
 
 MAINTAINER Ryan Lovett <rylo@berkeley.edu>
 

--- a/user/install-base-notebook.bash
+++ b/user/install-base-notebook.bash
@@ -1,4 +1,4 @@
 #!/bin/bash
 # This installs notebook and jupyterhub
-${CONDA_DIR}/bin/conda install --quiet --yes notebook==4.4.1
+${CONDA_DIR}/bin/conda install --quiet --yes notebook==4.4.1 ipykernel==4.6.0
 ${CONDA_DIR}/bin/pip install jupyterhub

--- a/user/install-base-notebook.bash
+++ b/user/install-base-notebook.bash
@@ -1,4 +1,4 @@
 #!/bin/bash
 # This installs notebook and jupyterhub
-${CONDA_DIR}/bin/conda install --quiet --yes notebook
+${CONDA_DIR}/bin/conda install --quiet --yes notebook==4.4.1
 ${CONDA_DIR}/bin/pip install jupyterhub


### PR DESCRIPTION
Pin notebook version to 4.4.1 so we don't upgrade to 5.0 accidentally.

Also upgrade ipykernel to get fix for https://github.com/ipython/ipykernel/pull/233