### PR TITLE
update git url for renaming nbinteract to nbpuller

### DIFF
--- a/user/install-extensions.bash
+++ b/user/install-extensions.bash
@@ -18,13 +18,13 @@ ${CONDA_DIR}/bin/jupyter nbextension install --sys-prefix --py nbresuse
 ${CONDA_DIR}/bin/jupyter nbextension enable --sys-prefix --py nbresuse
 
 # interact notebook extension
-${CONDA_DIR}/bin/pip install git+https://github.com/data-8/nbinteract.git@3fc207d
-#${CONDA_DIR}/bin/pip install git+https://github.com/data-8/nbinteract.git@branch-arg
+${CONDA_DIR}/bin/pip install git+https://github.com/data-8/nbpuller.git@3fc207d
+#${CONDA_DIR}/bin/pip install git+https://github.com/data-8/nbpuller.git@branch-arg
 # FIXME: This should just be in setup.py of the repo
 ${CONDA_DIR}/bin/pip --no-cache-dir install pytest webargs requests gitpython toolz
-${CONDA_DIR}/bin/jupyter serverextension enable --sys-prefix --py nbinteract
-${CONDA_DIR}/bin/jupyter nbextension install --sys-prefix --py nbinteract
-${CONDA_DIR}/bin/jupyter nbextension enable --sys-prefix --py nbinteract
+${CONDA_DIR}/bin/jupyter serverextension enable --sys-prefix --py nbpuller
+${CONDA_DIR}/bin/jupyter nbextension install --sys-prefix --py nbpuller
+${CONDA_DIR}/bin/jupyter nbextension enable --sys-prefix --py nbpuller
 
 ${CONDA_DIR}/bin/pip install git+https://github.com/data-8/nbgdrive.git@3a98798
 ${CONDA_DIR}/bin/jupyter serverextension enable --sys-prefix --py nbgdrive

--- a/user/install-extensions.bash
+++ b/user/install-extensions.bash
@@ -18,7 +18,7 @@ ${CONDA_DIR}/bin/jupyter nbextension install --sys-prefix --py nbresuse
 ${CONDA_DIR}/bin/jupyter nbextension enable --sys-prefix --py nbresuse
 
 # interact notebook extension
-${CONDA_DIR}/bin/pip install git+https://github.com/data-8/nbpuller.git@3be2ae3
+${CONDA_DIR}/bin/pip install git+https://github.com/data-8/nbpuller.git@2effb3e
 #${CONDA_DIR}/bin/pip install git+https://github.com/data-8/nbpuller.git@branch-arg
 # FIXME: This should just be in setup.py of the repo
 ${CONDA_DIR}/bin/pip --no-cache-dir install pytest webargs requests gitpython toolz

--- a/user/install-extensions.bash
+++ b/user/install-extensions.bash
@@ -18,7 +18,7 @@ ${CONDA_DIR}/bin/jupyter nbextension install --sys-prefix --py nbresuse
 ${CONDA_DIR}/bin/jupyter nbextension enable --sys-prefix --py nbresuse
 
 # interact notebook extension
-${CONDA_DIR}/bin/pip install git+https://github.com/data-8/nbpuller.git@3fc207d
+${CONDA_DIR}/bin/pip install git+https://github.com/data-8/nbpuller.git@3be2ae3
 #${CONDA_DIR}/bin/pip install git+https://github.com/data-8/nbpuller.git@branch-arg
 # FIXME: This should just be in setup.py of the repo
 ${CONDA_DIR}/bin/pip --no-cache-dir install pytest webargs requests gitpython toolz


### PR DESCRIPTION
Closes #68 

Summary
-------
Reflect renamed nbpuller (originally nbinteract) git repo in deployment settings. Updating the nbpuller to newest version.

How to test
-------
Try to build the user image.
