### PR TITLE
Add a pre-puller job as a chart hook

### DIFF
--- a/helm-chart/templates/pre-puller.yaml
+++ b/helm-chart/templates/pre-puller.yaml
@@ -1,0 +1,15 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: pull-all-nodes-{{.Release.Name}}-{{.Release.Revision}}
+  {{ if .Values.name }}namespace: {{ .Values.name }} {{ end }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - image: yuvipanda/image-allnodes-puller:v0.5
+          args: [{{ .Values.singleuser.image.name | quote }}, {{ .Values.singleuser.image.tag | quote }}]
+          name: all-nodes-puller


### PR DESCRIPTION
Uses https://github.com/yuvipanda/kube-image-puller to replace
populate.bash. This will be 'integrated' into the helm deploy
process, and also be faster since it'll be a lot more parallel!

We use a 'helm chart hook' to execute a job before each deploy. This
job in turn will launch another job, which will pull the image on all
nodes before exiting. The first job will wait for the second job to
fully finish before returning, and then helm will proceed with
normal deployment.